### PR TITLE
configure gradle with libs.versions.toml

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,12 +1,15 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.4.1'
-	id 'io.spring.dependency-management' version '1.1.7'
+	id 'application'
+	alias(libs.plugins.spring.boot)
+	alias(libs.plugins.spring.dep.mgmt)
+	//flyway plugin for db migration versioning
+	alias(libs.plugins.flyway)
 }
 
-group = 'com.example'
+group = 'org.latedriver'
 version = '0.0.1-SNAPSHOT'
 
+//Utilize specific java toolchain
 java {
 	toolchain {
 		languageVersion = JavaLanguageVersion.of(23)
@@ -18,10 +21,21 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.flywaydb:flyway-core'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation libs.spring.boot.starter.data
+	implementation libs.flyway.core
+	testImplementation libs.spring.boot.starter.test
+	testRuntimeOnly libs.junit.platform
+}
+
+flyway {
+	url =  '' //db url
+	user = '' //db user
+	password = '' //db pass
+	locations = [''] //migration script location
+}
+
+application {
+	mainClass = 'org.latedriver.whattracks.WhatTracksApp'
 }
 
 tasks.named('test') {

--- a/api/gradle/libs.versions.toml
+++ b/api/gradle/libs.versions.toml
@@ -1,0 +1,25 @@
+[versions]
+#libs
+spring-boot-starter-data = '3.4.1'
+spring-boot-starter-test = '3.4.1'
+flyway-core = '11.1.0'
+junit-platform = '1.11.4'
+#plugins
+spring-boot = '3.4.1'
+spring-dep-mgmt = '1.1.7'
+flyway = '11.1.0'
+
+[libraries]
+spring-boot-starter-data = {module = 'org.springframework.boot:spring-boot-starter-data-jpa', version.ref = 'spring-boot-starter-data'}
+spring-boot-starter-test = {module = 'org.springframework.boot:spring-boot-starter-test', version.ref = 'spring-boot-starter-test'}
+flyway-core = {module = 'org.flywaydb:flyway-core', version.ref = 'flyway-core'}
+junit-platform = {module = 'org.junit.platform:junit-platform-launcher', version.ref = 'junit-platform'}
+
+# [bundles]
+# spring-boot = ['spring-boot-starter-data', 'spring-boot-starter-test']
+
+[plugins]
+spring-boot = {id = 'org.springframework.boot', version.ref = 'spring-boot'}
+spring-dep-mgmt = {id = 'io.spring.dependency-management', version.ref = 'spring-dep-mgmt'}
+flyway = {id = 'org.flywaydb.flyway', version.ref = 'flyway'}
+

--- a/api/settings.gradle
+++ b/api/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'demo'
+rootProject.name = 'WhatTracks'

--- a/api/src/main/java/org/latedriver/whattracks/WhatTracksApp.java
+++ b/api/src/main/java/org/latedriver/whattracks/WhatTracksApp.java
@@ -1,13 +1,13 @@
-package com.example.demo;
+package org.latedriver.whattracks;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class WhatTracksApplication {
+public class WhatTracksApp {
 
 	public static void main(String[] args) {
-		SpringApplication.run(WhatTracksApplication.class, args);
+		SpringApplication.run(WhatTracksApp.class, args);
 	}
 
 }


### PR DESCRIPTION
This commit adds the libs.versions.toml to the api portion of the project for versioning libs and plugins. closes #7

- added deps, plugins to libs.versions.toml w/ versioning
- modified referenced libs, plugins in build.gradle to utilize those defined in libs.versions.toml
- moved WhatTracksApplication to WhatTracksApp in /java/org/latedriver/whattracks for correct java packaging convention